### PR TITLE
SendSMTPEmailBcc, SendSMTPEmailCc could be empty, or default [] cause…

### DIFF
--- a/models/send_smtp_email.go
+++ b/models/send_smtp_email.go
@@ -21,10 +21,10 @@ type SendSMTPEmail struct {
 	Attachment SendSMTPEmailAttachment `json:"attachment"`
 
 	// bcc
-	Bcc SendSMTPEmailBcc `json:"bcc"`
+	Bcc SendSMTPEmailBcc `json:"bcc,omitempty"`
 
 	// cc
-	Cc SendSMTPEmailCc `json:"cc"`
+	Cc SendSMTPEmailCc `json:"cc,omitempty"`
 
 	// headers
 	Headers map[string]string `json:"headers,omitempty"`


### PR DESCRIPTION
for current smtp api, blank cc or blank bcc [] would cause failed
for example
curl --request POST \
  --url https://api.sendinblue.com/v3/smtp/email \
  --header 'accept: application/json' \
  --header 'api-key:xxxx' \
  --header 'content-type: application/json' \
  --data '{  
   "sender":{  
      "name":"GGGGGG",
      "email":"xxxxxx"
   },
   "to":[  
      {  
         "email":"xxxxx",
         "name":"xxxx"
      }
   ],
   "cc": [],
   "subject":"Hello world",
   "htmlContent":"<html><head></head><body><p>Hello,</p>This is my first transactional email sent from Sendinblue.</p></body></html>"
}'

so for struct SendSMTPEmail
Bcc/Cc field should be able to be omitted
